### PR TITLE
Make the instance variable multi-valued, add its value to the legend

### DIFF
--- a/dashboards/microprofile.jsonnet
+++ b/dashboards/microprofile.jsonnet
@@ -55,6 +55,7 @@ local newdash = dashboard.new(
     'label_values(base_thread_count{env="$env",job="$job"}, instance)',
     label='Instance',
     refresh='time',
+    multi=true
   )
 );
 
@@ -70,8 +71,8 @@ local getTags(tags, type) =
       )
     );
 
-  if type == 'timer' then std.format('%s%s', ['{{job}} q={{quantile}}/', tagStr])
-  else '{{job}} ' + tagStr;
+  if type == 'timer' then std.format('%s%s', ['{{job}}/{{instance}} q={{quantile}}/', tagStr])
+  else '{{job}}/{{instance}} ' + tagStr;
 
 // map metric name to the OpenMetrics format based on microprofile metrics rules
 local makeOpenMetricName(name, type, unit, scope) =


### PR DESCRIPTION
Makes dashboards more friendly toward viewing metrics from multiple instances 
For example, a counter that exists on two instances `localhost:8080` and `localhost:8081` and has two variants on each instance, will look like this

![2020-06-22_14-06](https://user-images.githubusercontent.com/937315/85285962-1643fa00-b492-11ea-9391-c5e7275c43fd.png)

The Instance variable now supports multiple values
![image](https://user-images.githubusercontent.com/937315/85286044-370c4f80-b492-11ea-8541-9e905b5fe56b.png)

The problem with this is that some of the panels that we currently include don't support displaying multiple series at the same time, so when you select multiple instances, some plots stop working. So if accepted, the next step will be to change these panels to support something that supports multiple series. 